### PR TITLE
Msvc lambda fix

### DIFF
--- a/test/native.cpp
+++ b/test/native.cpp
@@ -203,14 +203,14 @@ void test_lambda(void) {
 
     {
         auto bar = [&]() {
-            int local_i = 0, local_j = 1;
-            BOOST_SCOPE_EXIT( (&local_i) (&local_j) ) {
-                local_i = local_j = 2; // modify references
+            int i = 0, j = 1;
+            BOOST_SCOPE_EXIT( (&i) (&j) ) {
+                i = j = 2; // modify references
             }
             BOOST_SCOPE_EXIT_END
 
-            BOOST_TEST(local_i == 2);
-            BOOST_TEST(local_j == 2);
+            BOOST_TEST(i == 2);
+            BOOST_TEST(j == 2);
         };
         bar();
     }

--- a/test/native.cpp
+++ b/test/native.cpp
@@ -185,10 +185,42 @@ void test_capture_all(void) {
 #endif // lambdas
 }
 
+void test_lambda(void) {
+
+    {
+        int i = 0, j = 1;
+        auto foo = [&]() {
+            BOOST_SCOPE_EXIT( (&i) (&j) ) {
+                i = j = 2; // modify references
+            }
+            BOOST_SCOPE_EXIT_END
+        };
+        foo();
+    
+        BOOST_TEST(i == 2);
+        BOOST_TEST(j == 2);
+    }
+
+    {
+        auto bar = [&]() {
+            int local_i = 0, local_j = 1;
+            BOOST_SCOPE_EXIT( (&local_i) (&local_j) ) {
+                local_i = local_j = 2; // modify references
+            }
+            BOOST_SCOPE_EXIT_END
+
+            BOOST_TEST(local_i == 2);
+            BOOST_TEST(local_j == 2);
+        };
+        bar();
+    }
+}
+
 int main(void) {
     test_non_local();
     test_types();
     test_capture_all();
+    test_lambda();
     return boost::report_errors();
 }
 


### PR DESCRIPTION
added test to check if BOOST_SCOPE_EXIT compiles when inside a lambda function (e.g. VS 2015 with Boost 1.65 and 1.66 fail on that)